### PR TITLE
Use 'reverse' instead of hard-coded urls everywhere

### DIFF
--- a/MemberManagement/templates/base/footer_legal.html
+++ b/MemberManagement/templates/base/footer_legal.html
@@ -4,5 +4,5 @@
 </p>
 <p>
     Copyright © 2017-{% now "y" %} Jacobs University Alumni Association. All Rights Reserved. <br>
-    <a href="/privacy/">Datenschutzerklärung / Privacy Policy</a> <a href="/imprint/">Impressum / Imprint</a>
+    <a href="{% url "privacy" %}">Datenschutzerklärung / Privacy Policy</a> <a href="{% url "imprint" %}">Impressum / Imprint</a>
 </p>

--- a/MemberManagement/templates/base/header.html
+++ b/MemberManagement/templates/base/header.html
@@ -24,7 +24,7 @@
         <nav class="uk-navbar" {% if show_devel_warning %}style="background: #fef4f6;"{% endif %}>
             <!-- logo -->
             <div class="uk-navbar-left">
-                <a href="/" class="uk-navbar-item uk-logo">
+                <a href="{% url "root" %}" class="uk-navbar-item uk-logo">
                     <span class="logo-button uk-margin-small-right">
                         <img src="{%  static "media/favicon.png" %}" />
                     </span>

--- a/MemberManagement/tests/integration.py
+++ b/MemberManagement/tests/integration.py
@@ -1,13 +1,11 @@
-from django.core.management import call_command
 from django.contrib.auth import get_user_model
-
-from seleniumlogin import force_login
-
-from selenium.webdriver.common.by import By
-from selenium.webdriver.support.ui import WebDriverWait, Select
-from selenium.webdriver.support import expected_conditions
-
+from django.core.management import call_command
+from django.urls import reverse
 from django_selenium_clean import SeleniumTestCase
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions
+from selenium.webdriver.support.ui import Select, WebDriverWait
+from seleniumlogin import force_login
 
 
 class IntegrationTest(SeleniumTestCase):
@@ -65,6 +63,11 @@ class IntegrationTest(SeleniumTestCase):
             Loads a URL using selenium from the live server and waits for the CSS selector (if any) to be available
             Returns the element selected, None if none is selected, or raises TimeoutException if a timeout occurs.
         """
+
+        # if the url does not start with '/', use reverse()
+        if not url.startswith('/'):
+            url = reverse(url)
+
         self.selenium.get(self.live_server_url + url)
         return self.wait_for_element(selector, timeout=timeout)
 

--- a/MemberManagement/tests/test_access.py
+++ b/MemberManagement/tests/test_access.py
@@ -1,34 +1,36 @@
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
+from django.urls import reverse
+
 from .integration import IntegrationTest
 
 PORTAL_FIXED = [
-    '/portal/',
-    '/portal/edit/',
-    '/portal/edit/address/',
-    '/portal/edit/social/',
-    '/portal/edit/jacobs/',
-    '/portal/edit/job/',
-    '/portal/edit/skills/',
-    '/portal/edit/atlas/'
+    reverse('portal'),
+    reverse('edit'),
+    reverse('edit_address'),
+    reverse('edit_social'),
+    reverse('edit_jacobs'),
+    reverse('edit_job'),
+    reverse('edit_skills'),
+    reverse('edit_atlas'),
 ]
 PORTAL_SETUP_URLS = [
-    '/',
-    '/register/',
-    '/portal/register/',
-    '/portal/setup/',
-    '/portal/setup/address/',
-    '/portal/setup/social/',
-    '/portal/setup/jacobs/',
-    '/portal/setup/job/',
-    '/portal/setup/skills/',
-    '/portal/setup/atlas/',
-    '/portal/setup/completed/'
+    reverse('root'),
+    reverse('root_register'),
+    reverse('register'),
+    reverse('setup'),
+    reverse('setup_address'),
+    reverse('setup_social'),
+    reverse('setup_jacobs'),
+    reverse('setup_job'),
+    reverse('setup_skills'),
+    reverse('setup_atlas'),
+    reverse('setup_setup'),
 ]
 SETUP_PROTECTED_URLS = PORTAL_SETUP_URLS + PORTAL_FIXED + [
-    '/payments/membership/',
-    '/payments/subscribe/',
-    '/payments/update/',
-    '/payments/'
+    reverse('setup_membership'),
+    reverse('setup_subscription'),
+    reverse('update_subscription'),
+    reverse('view_payments'),
 ]
 
 
@@ -36,17 +38,21 @@ class HomeAccessTest(IntegrationTest, StaticLiveServerTestCase):
     """ Checks that the homepage redirects appropriatly for the different stages of approval """
 
     def test_none(self):
-        self.assertEqual(self.sfollow('/', '.main-container'), '/')
+        ROOT = reverse('root')
+        ROOT_REGISTER = reverse('root_register')
+        REGISTER = reverse('register')
+
+        self.assertEqual(self.sfollow('root', '.main-container'), ROOT)
         self.assertEqual(self.sfollow(
-            '/register/', '.main-container'), '/portal/register/')
-        self.assertEqual(self.sfollow('/portal/register/',
-                                      '.main-container'), '/portal/register/')
+            'root_register', '.main-container'), REGISTER)
+        self.assertEqual(self.sfollow('register',
+                                      '.main-container'), REGISTER)
 
         for url in SETUP_PROTECTED_URLS:
-            if url in ['/', '/register/', '/portal/register/']:
+            if url in [ROOT, ROOT_REGISTER, REGISTER]:
                 continue
             self.assertEqual(self.sfollow(url, '.main-container'),
-                             '/auth/login/?next={}'.format(url), '{} redirects to login page'.format(url))
+                             reverse('login')+'?next={}'.format(url), '{} redirects to login page'.format(url))
 
     def test_setup_address(self):
         self.load_fixture('registry/tests/fixtures/signup_00_register.json')
@@ -55,7 +61,7 @@ class HomeAccessTest(IntegrationTest, StaticLiveServerTestCase):
         # check that all the protected urls go to the first page of the setup
         for url in SETUP_PROTECTED_URLS:
             self.assertEqual(self.sfollow(url, '.main-container'),
-                             '/portal/setup/address/', '{} redirects to address setup'.format(url))
+                             reverse('setup_address'), '{} redirects to address setup'.format(url))
 
     def test_setup_social(self):
         self.load_fixture('registry/tests/fixtures/signup_01_address.json')
@@ -63,7 +69,7 @@ class HomeAccessTest(IntegrationTest, StaticLiveServerTestCase):
 
         for url in SETUP_PROTECTED_URLS:
             self.assertEqual(self.sfollow(url, '.main-container'),
-                             '/portal/setup/social/', '{} redirects to social setup'.format(url))
+                             reverse('setup_social'), '{} redirects to social setup'.format(url))
 
     def test_setup_jacobs(self):
         self.load_fixture('registry/tests/fixtures/signup_02_social.json')
@@ -71,7 +77,7 @@ class HomeAccessTest(IntegrationTest, StaticLiveServerTestCase):
 
         for url in SETUP_PROTECTED_URLS:
             self.assertEqual(self.sfollow(url, '.main-container'),
-                             '/portal/setup/jacobs/', '{} redirects to jacobs setup'.format(url))
+                             reverse('setup_jacobs'), '{} redirects to jacobs setup'.format(url))
 
     def test_setup_job(self):
         self.load_fixture('registry/tests/fixtures/signup_03_jacobs.json')
@@ -79,7 +85,7 @@ class HomeAccessTest(IntegrationTest, StaticLiveServerTestCase):
 
         for url in SETUP_PROTECTED_URLS:
             self.assertEqual(self.sfollow(url, '.main-container'),
-                             '/portal/setup/job/', '{} redirects to job setup'.format(url))
+                             reverse('setup_job'), '{} redirects to job setup'.format(url))
 
     def test_setup_skills(self):
         self.load_fixture('registry/tests/fixtures/signup_04_job.json')
@@ -87,7 +93,7 @@ class HomeAccessTest(IntegrationTest, StaticLiveServerTestCase):
 
         for url in SETUP_PROTECTED_URLS:
             self.assertEqual(self.sfollow(url, '.main-container'),
-                             '/portal/setup/skills/', '{} redirects to skills setup'.format(url))
+                             reverse('setup_skills'), '{} redirects to skills setup'.format(url))
 
     def test_setup_atlas(self):
         self.load_fixture('registry/tests/fixtures/signup_05_skills.json')
@@ -95,7 +101,7 @@ class HomeAccessTest(IntegrationTest, StaticLiveServerTestCase):
 
         for url in SETUP_PROTECTED_URLS:
             self.assertEqual(self.sfollow(url, '.main-container'),
-                             '/portal/setup/atlas/', '{} redirects to atlas setup'.format(url))
+                             reverse('setup_atlas'), '{} redirects to atlas setup'.format(url))
 
     def test_setup_tier(self):
         self.load_fixture('registry/tests/fixtures/signup_06_atlas.json')
@@ -103,7 +109,7 @@ class HomeAccessTest(IntegrationTest, StaticLiveServerTestCase):
 
         for url in SETUP_PROTECTED_URLS:
             self.assertEqual(self.sfollow(url, '.main-container'),
-                             '/payments/membership/', '{} redirects to membership setup'.format(url))
+                             reverse('setup_membership'), '{} redirects to membership setup'.format(url))
 
     def test_setup_starter(self):
         self.load_fixture('registry/tests/fixtures/signup_07a_starter.json')
@@ -111,7 +117,7 @@ class HomeAccessTest(IntegrationTest, StaticLiveServerTestCase):
 
         for url in SETUP_PROTECTED_URLS:
             self.assertEqual(self.sfollow(url, '.main-container'),
-                             '/portal/setup/completed/', '{} redirects to completed setup'.format(url))
+                             reverse('setup_setup'), '{} redirects to completed setup'.format(url))
 
     def test_setup_completed(self):
         self.load_fixture('registry/tests/fixtures/signup_09_finalize.json')
@@ -123,4 +129,4 @@ class HomeAccessTest(IntegrationTest, StaticLiveServerTestCase):
 
         for url in PORTAL_SETUP_URLS:
             self.assertEqual(self.sfollow(url, '.main-container'),
-                             '/portal/', '{} redirects to portal home'.format(url))
+                             reverse('portal'), '{} redirects to portal home'.format(url))

--- a/MemberManagement/tests/test_cookies.py
+++ b/MemberManagement/tests/test_cookies.py
@@ -1,19 +1,20 @@
-from django.contrib.staticfiles.testing import StaticLiveServerTestCase
-from MemberManagement.tests.integration import IntegrationTest
-
 import time
+
+from django.contrib.staticfiles.testing import StaticLiveServerTestCase
+
+from MemberManagement.tests.integration import IntegrationTest
 
 
 class CookieTest(IntegrationTest, StaticLiveServerTestCase):
     def test_cookiebanner_works(self):
 
         # check that loading the page for the first time shows the banner
-        self.sget("/")
+        self.sget('root')
         self.assertTrue(self.selenium.find_element_by_id(
             'CookielawBanner').is_displayed())
 
         # reload the page, it should still be there
-        self.sget("/")
+        self.sget('root')
         self.assertTrue(self.selenium.find_element_by_id(
             'CookielawBanner').is_displayed())
 
@@ -24,5 +25,5 @@ class CookieTest(IntegrationTest, StaticLiveServerTestCase):
             'CookielawBanner').is_displayed())
 
         # reload the page, it should no longer be there
-        self.sget("/")
+        self.sget('root')
         self.assertFalse(self.element_exists('#CookielawBanner'))

--- a/MemberManagement/urls.py
+++ b/MemberManagement/urls.py
@@ -14,18 +14,18 @@ Including another URLconf
     2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
 """
 from django.conf.urls import include, url
-
-from django.views.generic import TemplateView, RedirectView
+from django.views.generic import RedirectView, TemplateView
 
 from .views import HomeView
 
 urlpatterns = [
     # Static Views
-    url(r'^$', HomeView.as_view()),
+    url(r'^$', HomeView.as_view(), name='root'),
     url(r'^imprint/$', TemplateView.as_view(template_name="static/imprint.html"), name='imprint'),
 
     # Legacy urls
-    url(r'^register/$', RedirectView.as_view(pattern_name='register', permanent=False)),
+    url(r'^register/$', RedirectView.as_view(pattern_name='register',
+                                             permanent=False), name='root_register'),
     url(r'^privacy/$', RedirectView.as_view(url='https://jacobs-alumni.de/privacy/',
                                             permanent=False), name='privacy'),
 

--- a/atlas/views.py
+++ b/atlas/views.py
@@ -1,24 +1,18 @@
-from django.conf import settings
-from django.http import Http404
-from django.shortcuts import get_object_or_404
 from django.contrib.auth.decorators import login_required
-from django.utils.decorators import method_decorator
-from django.views.generic import TemplateView, ListView
 from django.core.exceptions import ObjectDoesNotExist
-
-from django.core.paginator import Paginator
-from django.core.paginator import EmptyPage
-from django.core.paginator import PageNotAnInteger
-
-from alumni.models import Alumni, Address
-
-from alumni.fields import CollegeField, ClassField, MajorField, DegreeField, IndustryField, JobField, CountryField
-
-from django.shortcuts import redirect
+from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
+from django.http import Http404
+from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse
+from django.utils.decorators import method_decorator
+from django.views.generic import ListView, TemplateView
 
+from alumni.fields import (ClassField, CollegeField, CountryField, DegreeField,
+                           IndustryField, JobField, MajorField)
+from alumni.models import Address, Alumni
 # Create a new SearchFilter instance
-from registry.search.filter import SearchFilter, ParsingError
+from registry.search.filter import ParsingError, SearchFilter
+
 search = SearchFilter({
     'city': 'address__city',
     'country': 'address__country',

--- a/registry/forms.py
+++ b/registry/forms.py
@@ -1,11 +1,10 @@
 from django import forms
-
-from alumni.models import Alumni, Address, JacobsData, SocialMedia, \
-    JobInformation, Skills, SetupCompleted
-from atlas.models import AtlasSettings
 from django.contrib.auth.models import User
-from django_forms_uikit.widgets import DatePickerInput
 
+from alumni.models import (Address, Alumni, JacobsData, JobInformation,
+                           SetupCompleted, Skills, SocialMedia)
+from atlas.models import AtlasSettings
+from django_forms_uikit.widgets import DatePickerInput
 
 EMAIL_BLACKLIST = [
     'jacobs-alumni.de',
@@ -35,9 +34,8 @@ class RegistrationForm(RegistrationMixin, forms.ModelForm):
     username = forms.SlugField(label='Username',
                                help_text='Select your username for the membership portal. '
                                          'We recommend your alumni email username, e.g. <em>ppan</em> for <em>Peter Pan</em>')
-
     _tos_help_text = 'I confirm that I have read and agree to the ' \
-                     '<a target="_blank" href="/privacy">Terms and Conditions' \
+                     '<a target="_blank" href="https://jacobs-alumni.de/privacy/">Terms and Conditions' \
                      '</a>, the <a target="_blank" href="' \
                      'https://jacobs-alumni.de/charter">Charter</a>, and the ' \
                      '<a target="_blank" href="https://www.jacobs-alumni.de/by-laws">Contributions By-Laws</a>. '

--- a/registry/tests/test_edit_01_general.py
+++ b/registry/tests/test_edit_01_general.py
@@ -1,11 +1,12 @@
+import datetime
+
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
+from django.urls import reverse
 
 from alumni.fields.category import AlumniCategoryField
 from alumni.fields.gender import GenderField
 from alumni.models import Alumni
 from MemberManagement.tests.integration import IntegrationTest
-
-import datetime
 
 
 class EditDataTest(IntegrationTest, StaticLiveServerTestCase):
@@ -20,10 +21,10 @@ class EditDataTest(IntegrationTest, StaticLiveServerTestCase):
         """ Tests that entering nothing doesn't change anything """
 
         # enter nothing
-        self.submit_form('/portal/edit/', 'input_id_submit')
+        self.submit_form('edit', 'input_id_submit')
 
         # check that nothing happened
-        self.assertEqual(self.current_url, '/portal/edit/',
+        self.assertEqual(self.current_url, reverse('edit'),
                          'Check that we stayed on the right page')
 
         # check that everything stayed the same
@@ -44,7 +45,7 @@ class EditDataTest(IntegrationTest, StaticLiveServerTestCase):
     def test_data_regular(self):
         """ Tests that all fields can be changed """
 
-        self.submit_form('/portal/edit/', 'input_id_submit', send_form_keys={
+        self.submit_form('edit', 'input_id_submit', send_form_keys={
             'id_givenName': 'John',
             'id_middleName': 'C',
             'id_familyName': 'Day',
@@ -58,7 +59,7 @@ class EditDataTest(IntegrationTest, StaticLiveServerTestCase):
         })
 
         # check that we got redirected to the right url
-        self.assertEqual(self.current_url, '/portal/edit/',
+        self.assertEqual(self.current_url, reverse('edit'),
                          'Check that we stayed on the right page')
 
         # check that the right alumni object was created
@@ -79,12 +80,12 @@ class EditDataTest(IntegrationTest, StaticLiveServerTestCase):
         """ Tests that we can't use a jacobs email as private email """
 
         # enter nothing
-        self.submit_form('/portal/edit/', 'input_id_submit', send_form_keys={
+        self.submit_form('edit', 'input_id_submit', send_form_keys={
             'id_email': 'AnnaFreytag@jacobs-university.de',
         })
 
         # check that we stayed on the page, but the email field was marked incorrect
-        self.assertEqual(self.current_url, '/portal/edit/',
+        self.assertEqual(self.current_url, reverse('edit'),
                          'Check that we stayed on the right page')
         self.assertIn('uk-form-danger', self.selenium.find_element_by_id(
             'id_email').get_attribute('class').split(' '), 'email field marked up as incorrect')

--- a/registry/tests/test_edit_02_atlas.py
+++ b/registry/tests/test_edit_02_atlas.py
@@ -1,4 +1,5 @@
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
+from django.urls import reverse
 
 from alumni.models import Alumni
 from MemberManagement.tests.integration import IntegrationTest
@@ -16,10 +17,10 @@ class EditAtlasTest(IntegrationTest, StaticLiveServerTestCase):
         """ Tests that entering nothing doesn't change anything """
 
         # enter nothing
-        self.submit_form('/portal/edit/atlas/', 'input_id_submit')
+        self.submit_form('edit_atlas', 'input_id_submit')
 
         # check that nothing happened
-        self.assertEqual(self.current_url, '/portal/edit/atlas/',
+        self.assertEqual(self.current_url, reverse('edit_atlas'),
                          'Check that we stayed on the right page')
 
         # check that everything stayed the same
@@ -28,13 +29,13 @@ class EditAtlasTest(IntegrationTest, StaticLiveServerTestCase):
         self.assertEqual(self.obj.atlas.contactInfoVisible, True)
 
     def test_signup_atlas_birthday(self):
-        self.submit_form('/portal/edit/atlas/', 'input_id_submit', select_checkboxes={
+        self.submit_form('edit_atlas', 'input_id_submit', select_checkboxes={
             'id_included': True,
             'id_birthdayVisible': True,
             'id_contactInfoVisible': False,
         })
 
-        self.assertEqual(self.current_url, '/portal/edit/atlas/',
+        self.assertEqual(self.current_url, reverse('edit_atlas'),
                          'Check that we stayed on the right page')
 
         self.assertEqual(self.obj.atlas.included, True)
@@ -42,13 +43,13 @@ class EditAtlasTest(IntegrationTest, StaticLiveServerTestCase):
         self.assertEqual(self.obj.atlas.contactInfoVisible, False)
 
     def test_signup_atlas_contact(self):
-        self.submit_form('/portal/edit/atlas/', 'input_id_submit', select_checkboxes={
+        self.submit_form('edit_atlas', 'input_id_submit', select_checkboxes={
             'id_included': True,
             'id_birthdayVisible': False,
             'id_contactInfoVisible': True,
         })
 
-        self.assertEqual(self.current_url, '/portal/edit/atlas/',
+        self.assertEqual(self.current_url, reverse('edit_atlas'),
                          'Check that we stayed on the right page')
 
         self.assertEqual(self.obj.atlas.included, True)
@@ -56,13 +57,13 @@ class EditAtlasTest(IntegrationTest, StaticLiveServerTestCase):
         self.assertEqual(self.obj.atlas.contactInfoVisible, True)
 
     def test_signup_atlas_minimal(self):
-        self.submit_form('/portal/edit/atlas/', 'input_id_submit', select_checkboxes={
+        self.submit_form('edit_atlas', 'input_id_submit', select_checkboxes={
             'id_included': True,
             'id_birthdayVisible': False,
             'id_contactInfoVisible': False,
         })
 
-        self.assertEqual(self.current_url, '/portal/edit/atlas/',
+        self.assertEqual(self.current_url, reverse('edit_atlas'),
                          'Check that we stayed on the right page')
 
         self.assertEqual(self.obj.atlas.included, True)
@@ -70,13 +71,13 @@ class EditAtlasTest(IntegrationTest, StaticLiveServerTestCase):
         self.assertEqual(self.obj.atlas.contactInfoVisible, False)
 
     def test_signup_atlas_empty(self):
-        self.submit_form('/portal/edit/atlas/', 'input_id_submit', select_checkboxes={
+        self.submit_form('edit_atlas', 'input_id_submit', select_checkboxes={
             'id_included': False,
             'id_birthdayVisible': False,
             'id_contactInfoVisible': False,
         })
 
-        self.assertEqual(self.current_url, '/portal/edit/atlas/',
+        self.assertEqual(self.current_url, reverse('edit_atlas'),
                          'Check that we stayed on the right page')
 
         obj = Alumni.objects.first().atlas

--- a/registry/tests/test_edit_03_address.py
+++ b/registry/tests/test_edit_03_address.py
@@ -1,4 +1,5 @@
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
+from django.urls import reverse
 
 from alumni.models import Alumni
 from MemberManagement.tests.integration import IntegrationTest
@@ -16,10 +17,10 @@ class EditAddressTest(IntegrationTest, StaticLiveServerTestCase):
         """ Tests that entering nothing doesn't change anything """
 
         # enter nothing
-        self.submit_form('/portal/edit/address/', 'input_id_submit')
+        self.submit_form('edit_address', 'input_id_submit')
 
         # check that nothing happened
-        self.assertEqual(self.current_url, '/portal/edit/address/',
+        self.assertEqual(self.current_url, reverse('edit_address'),
                          'Check that we stayed on the right page')
 
         # check that everything stayed the same
@@ -34,7 +35,7 @@ class EditAddressTest(IntegrationTest, StaticLiveServerTestCase):
         """ Tests that adding a full address works """
 
         # enter nothing
-        self.submit_form('/portal/edit/address/', 'input_id_submit', send_form_keys={
+        self.submit_form('edit_address', 'input_id_submit', send_form_keys={
             'id_address_line_1': '2986 Heron Way',
             'id_address_line_2': 'Attn. Anna Freytag',
             'id_city': 'Portland',
@@ -45,7 +46,7 @@ class EditAddressTest(IntegrationTest, StaticLiveServerTestCase):
         })
 
         # check that nothing happened
-        self.assertEqual(self.current_url, '/portal/edit/address/',
+        self.assertEqual(self.current_url, reverse('edit_address'),
                          'Check that we stayed on the right page')
 
         # check that we edited it right
@@ -61,7 +62,7 @@ class EditAddressTest(IntegrationTest, StaticLiveServerTestCase):
         """ Tests that adding a full address works """
 
         # enter nothing
-        button = self.fill_out_form('/portal/edit/address/', 'input_id_submit', send_form_keys={
+        button = self.fill_out_form('edit_address', 'input_id_submit', send_form_keys={
             'id_address_line_1': '',
             'id_address_line_2': '',
             'id_city': '',
@@ -77,7 +78,7 @@ class EditAddressTest(IntegrationTest, StaticLiveServerTestCase):
         self.wait_for_element('.main-container')
 
         # check that nothing happened
-        self.assertEqual(self.current_url, '/portal/edit/address/',
+        self.assertEqual(self.current_url, reverse('edit_address'),
                          'Check that we stayed on the right page')
 
         # check that nothing was edited

--- a/registry/tests/test_edit_04_jacobs.py
+++ b/registry/tests/test_edit_04_jacobs.py
@@ -1,11 +1,12 @@
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
-from MemberManagement.tests.integration import IntegrationTest
+from django.urls import reverse
 
-from alumni.models import Alumni
 from alumni.fields.college import CollegeField
 from alumni.fields.degree import DegreeField
 from alumni.fields.major import MajorField
 from alumni.fields.year import ClassField
+from alumni.models import Alumni
+from MemberManagement.tests.integration import IntegrationTest
 
 
 class EditJacobsTest(IntegrationTest, StaticLiveServerTestCase):
@@ -20,10 +21,10 @@ class EditJacobsTest(IntegrationTest, StaticLiveServerTestCase):
         """ Tests that entering nothing doesn't change anything """
 
         # enter nothing
-        self.submit_form('/portal/edit/jacobs/', 'input_id_submit')
+        self.submit_form('edit_jacobs', 'input_id_submit')
 
         # check that nothing happened
-        self.assertEqual(self.current_url, '/portal/edit/jacobs/',
+        self.assertEqual(self.current_url, reverse('edit_jacobs'),
                          'Check that we stayed on the right page')
 
         # check that everything stayed the same
@@ -34,7 +35,7 @@ class EditJacobsTest(IntegrationTest, StaticLiveServerTestCase):
         self.assertEqual(self.obj.jacobs.comments, 'I am not real')
 
     def test_edit_complete(self):
-        self.submit_form('/portal/edit/jacobs/', 'input_id_submit', send_form_keys={
+        self.submit_form('edit_jacobs', 'input_id_submit', send_form_keys={
             'id_comments': 'I am real',
         }, select_dropdowns={
             'id_college': 'College III',
@@ -44,7 +45,7 @@ class EditJacobsTest(IntegrationTest, StaticLiveServerTestCase):
         })
 
         # check that we stayed on the right page
-        self.assertEqual(self.current_url, '/portal/edit/jacobs/',
+        self.assertEqual(self.current_url, reverse('edit_jacobs'),
                          'Check that we stayed on the right page')
 
         # check that everything stayed the same
@@ -55,7 +56,7 @@ class EditJacobsTest(IntegrationTest, StaticLiveServerTestCase):
         self.assertEqual(self.obj.jacobs.comments, 'I am real')
 
     def test_edit_empty(self):
-        self.submit_form('/portal/edit/jacobs/', 'input_id_submit', send_form_keys={
+        self.submit_form('edit_jacobs', 'input_id_submit', send_form_keys={
             'id_comments': '',
         }, select_dropdowns={
             'id_college': '---------',
@@ -65,7 +66,7 @@ class EditJacobsTest(IntegrationTest, StaticLiveServerTestCase):
         })
 
         # check that we stayed on the right page
-        self.assertEqual(self.current_url, '/portal/edit/jacobs/',
+        self.assertEqual(self.current_url, reverse('edit_jacobs'),
                          'Check that we stayed on the right page')
 
         # check that everything stayed the same

--- a/registry/tests/test_edit_05_social.py
+++ b/registry/tests/test_edit_05_social.py
@@ -1,4 +1,5 @@
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
+from django.urls import reverse
 
 from alumni.models import Alumni
 from MemberManagement.tests.integration import IntegrationTest
@@ -16,10 +17,10 @@ class EditSocialTest(IntegrationTest, StaticLiveServerTestCase):
         """ Tests that entering nothing doesn't change anything """
 
         # enter nothing
-        self.submit_form('/portal/edit/social/', 'input_id_submit')
+        self.submit_form('edit_social', 'input_id_submit')
 
         # check that nothing happened
-        self.assertEqual(self.current_url, '/portal/edit/social/',
+        self.assertEqual(self.current_url, reverse('edit_social'),
                          'Check that we stayed on the right page')
 
         # check that everything stayed the same
@@ -37,7 +38,7 @@ class EditSocialTest(IntegrationTest, StaticLiveServerTestCase):
         """ Tests that entering nothing doesn't change anything """
 
         # enter nothing
-        self.submit_form('/portal/edit/social/', 'input_id_submit', send_form_keys={
+        self.submit_form('edit_social', 'input_id_submit', send_form_keys={
             'id_facebook': 'https://facebook.com/freytag',
             'id_linkedin': 'https://www.linkedin.com/in/freytag-1234578',
             'id_twitter': 'https://twitter.com/freytag',
@@ -46,7 +47,7 @@ class EditSocialTest(IntegrationTest, StaticLiveServerTestCase):
         })
 
         # check that nothing happened
-        self.assertEqual(self.current_url, '/portal/edit/social/',
+        self.assertEqual(self.current_url, reverse('edit_social'),
                          'Check that we stayed on the right page')
 
         # check that everything updated
@@ -62,7 +63,7 @@ class EditSocialTest(IntegrationTest, StaticLiveServerTestCase):
 
     def test_edit_empty(self):
         # enter nothing
-        self.submit_form('/portal/edit/social/', 'input_id_submit', send_form_keys={
+        self.submit_form('edit_social', 'input_id_submit', send_form_keys={
             'id_facebook': '',
             'id_linkedin': '',
             'id_twitter': '',
@@ -71,7 +72,7 @@ class EditSocialTest(IntegrationTest, StaticLiveServerTestCase):
         })
 
         # check that nothing happened
-        self.assertEqual(self.current_url, '/portal/edit/social/',
+        self.assertEqual(self.current_url, reverse('edit_social'),
                          'Check that we stayed on the right page')
 
         # check that everything updated

--- a/registry/tests/test_edit_06_job.py
+++ b/registry/tests/test_edit_06_job.py
@@ -1,9 +1,10 @@
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
-from MemberManagement.tests.integration import IntegrationTest
+from django.urls import reverse
 
-from alumni.models import Alumni
 from alumni.fields.industry import IndustryField
 from alumni.fields.job import JobField
+from alumni.models import Alumni
+from MemberManagement.tests.integration import IntegrationTest
 
 
 class EditJobTest(IntegrationTest, StaticLiveServerTestCase):
@@ -18,10 +19,10 @@ class EditJobTest(IntegrationTest, StaticLiveServerTestCase):
         """ Tests that entering nothing doesn't change anything """
 
         # enter nothing
-        self.submit_form('/portal/edit/job/', 'input_id_submit')
+        self.submit_form('edit_job', 'input_id_submit')
 
         # check that nothing happened
-        self.assertEqual(self.current_url, '/portal/edit/job/',
+        self.assertEqual(self.current_url, reverse('edit_job'),
                          'Check that we stayed on the right page')
 
         # check that everything stayed the same
@@ -32,7 +33,7 @@ class EditJobTest(IntegrationTest, StaticLiveServerTestCase):
 
     def test_edit_complete(self):
         # enter nothing
-        self.submit_form('/portal/edit/job/', 'input_id_submit', send_form_keys={
+        self.submit_form('edit_job', 'input_id_submit', send_form_keys={
             'id_employer': 'Problem Dream',
             'id_position': 'Senior Production Consultant',
         }, select_dropdowns={
@@ -41,7 +42,7 @@ class EditJobTest(IntegrationTest, StaticLiveServerTestCase):
         })
 
         # check that nothing happened
-        self.assertEqual(self.current_url, '/portal/edit/job/',
+        self.assertEqual(self.current_url, reverse('edit_job'),
                          'Check that we stayed on the right page')
 
         # check that everything saved
@@ -52,7 +53,7 @@ class EditJobTest(IntegrationTest, StaticLiveServerTestCase):
 
     def test_edit_empty(self):
         # enter nothing
-        self.submit_form('/portal/edit/job/', 'input_id_submit', send_form_keys={
+        self.submit_form('edit_job', 'input_id_submit', send_form_keys={
             'id_employer': '',
             'id_position': '',
         }, select_dropdowns={
@@ -61,7 +62,7 @@ class EditJobTest(IntegrationTest, StaticLiveServerTestCase):
         })
 
         # check that nothing happened
-        self.assertEqual(self.current_url, '/portal/edit/job/',
+        self.assertEqual(self.current_url, reverse('edit_job'),
                          'Check that we stayed on the right page')
 
         # check that everything saved

--- a/registry/tests/test_edit_07_skills.py
+++ b/registry/tests/test_edit_07_skills.py
@@ -1,7 +1,8 @@
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
-from MemberManagement.tests.integration import IntegrationTest
+from django.urls import reverse
 
 from alumni.models import Alumni
+from MemberManagement.tests.integration import IntegrationTest
 
 
 class EditJobTest(IntegrationTest, StaticLiveServerTestCase):
@@ -16,22 +17,26 @@ class EditJobTest(IntegrationTest, StaticLiveServerTestCase):
         """ Tests that entering nothing doesn't change anything """
 
         # enter nothing
-        self.submit_form('/portal/edit/skills/', 'input_id_submit')
+        self.submit_form('edit_skills', 'input_id_submit')
 
         # check that nothing happened
-        self.assertEqual(self.current_url, '/portal/edit/skills/',
+        self.assertEqual(self.current_url, reverse('edit_skills'),
                          'Check that we stayed on the right page')
 
         # check that everything stayed the same
-        self.assertEqual(self.obj.skills.otherDegrees, "Bachelor of Computer Science from IUB")
-        self.assertEqual(self.obj.skills.spokenLanguages, "German, English, Spanish")
-        self.assertEqual(self.obj.skills.programmingLanguages, "HTML, CSS, JavaScript, Python")
-        self.assertEqual(self.obj.skills.areasOfInterest, "Start-Ups, Surfing, Big Data, Human Rights")
+        self.assertEqual(self.obj.skills.otherDegrees,
+                         "Bachelor of Computer Science from IUB")
+        self.assertEqual(self.obj.skills.spokenLanguages,
+                         "German, English, Spanish")
+        self.assertEqual(self.obj.skills.programmingLanguages,
+                         "HTML, CSS, JavaScript, Python")
+        self.assertEqual(self.obj.skills.areasOfInterest,
+                         "Start-Ups, Surfing, Big Data, Human Rights")
         self.assertEqual(self.obj.skills.alumniMentor, False)
 
     def test_edit_complete(self):
         # enter nothing
-        self.submit_form('/portal/edit/skills/', 'input_id_submit', send_form_keys={
+        self.submit_form('edit_skills', 'input_id_submit', send_form_keys={
             'id_otherDegrees': 'Fancy Degree from FancyU',
             'id_spokenLanguages': 'English, German, Spanish',
             'id_programmingLanguages': 'CSS, HTML, JavaScript, Python',
@@ -41,19 +46,22 @@ class EditJobTest(IntegrationTest, StaticLiveServerTestCase):
         })
 
         # check that nothing happened
-        self.assertEqual(self.current_url, '/portal/edit/skills/',
+        self.assertEqual(self.current_url, reverse('edit_skills'),
                          'Check that we stayed on the right page')
 
         # check that everything saved
-        self.assertEqual(self.obj.skills.otherDegrees, "Fancy Degree from FancyU")
-        self.assertEqual(self.obj.skills.spokenLanguages, "English, German, Spanish")
-        self.assertEqual(self.obj.skills.programmingLanguages, "CSS, HTML, JavaScript, Python")
+        self.assertEqual(self.obj.skills.otherDegrees,
+                         "Fancy Degree from FancyU")
+        self.assertEqual(self.obj.skills.spokenLanguages,
+                         "English, German, Spanish")
+        self.assertEqual(self.obj.skills.programmingLanguages,
+                         "CSS, HTML, JavaScript, Python")
         self.assertEqual(self.obj.skills.areasOfInterest, "Nothing at all")
         self.assertEqual(self.obj.skills.alumniMentor, True)
 
     def test_edit_empty(self):
         # enter nothing
-        self.submit_form('/portal/edit/skills/', 'input_id_submit', send_form_keys={
+        self.submit_form('edit_skills', 'input_id_submit', send_form_keys={
             'id_otherDegrees': '',
             'id_spokenLanguages': '',
             'id_programmingLanguages': '',
@@ -63,7 +71,7 @@ class EditJobTest(IntegrationTest, StaticLiveServerTestCase):
         })
 
         # check that nothing happened
-        self.assertEqual(self.current_url, '/portal/edit/skills/',
+        self.assertEqual(self.current_url, reverse('edit_skills'),
                          'Check that we stayed on the right page')
 
         # check that everything saved

--- a/registry/tests/test_signup_00_register.py
+++ b/registry/tests/test_signup_00_register.py
@@ -1,11 +1,12 @@
-from django.contrib.staticfiles.testing import StaticLiveServerTestCase
-from MemberManagement.tests.integration import IntegrationTest
-
 import datetime
 
-from alumni.models import Alumni
-from alumni.fields.gender import GenderField
+from django.contrib.staticfiles.testing import StaticLiveServerTestCase
+from django.urls import reverse
+
 from alumni.fields.category import AlumniCategoryField
+from alumni.fields.gender import GenderField
+from alumni.models import Alumni
+from MemberManagement.tests.integration import IntegrationTest
 
 
 class SignupTest(IntegrationTest, StaticLiveServerTestCase):
@@ -13,7 +14,7 @@ class SignupTest(IntegrationTest, StaticLiveServerTestCase):
         """ Tests that we can complete the first setup page with a regular user """
 
         # fill out a new form on the register page
-        self.submit_form('/portal/register/', 'input_id_submit', send_form_keys={
+        self.submit_form('register', 'input_id_submit', send_form_keys={
             'id_givenName': 'Anna',
             'id_middleName': '',
             'id_familyName': 'Freytag',
@@ -31,7 +32,7 @@ class SignupTest(IntegrationTest, StaticLiveServerTestCase):
         })
 
         # check that we got redirected to the right url
-        self.assertEqual(self.current_url, '/portal/setup/address/',
+        self.assertEqual(self.current_url, reverse('setup_address'),
                          'Check that the user gets redirected to the second page')
 
         # check that the right alumni object was created
@@ -59,7 +60,7 @@ class SignupTest(IntegrationTest, StaticLiveServerTestCase):
         """ Tests that we can complete the first signup page for a faculty member """
 
         # fill out a new form on the register page
-        self.submit_form('/portal/register/', 'input_id_submit', send_form_keys={
+        self.submit_form('register', 'input_id_submit', send_form_keys={
             'id_givenName': 'David',
             'id_middleName': 'L',
             'id_familyName': 'Hood',
@@ -78,7 +79,7 @@ class SignupTest(IntegrationTest, StaticLiveServerTestCase):
         })
 
         # check that we got redirected to the right url
-        self.assertEqual(self.current_url, '/portal/setup/address/',
+        self.assertEqual(self.current_url, reverse('setup_address'),
                          'Check that the user gets redirected to the second page')
 
         # check that the right alumni object was created
@@ -106,7 +107,7 @@ class SignupTest(IntegrationTest, StaticLiveServerTestCase):
         """ Tests that we can not submit a form without having accepted the TOS """
 
         # fill out the form first
-        button = self.fill_out_form('/portal/register/', 'input_id_submit', send_form_keys={
+        button = self.fill_out_form('register', 'input_id_submit', send_form_keys={
             'id_givenName': 'Anna',
             'id_middleName': '',
             'id_familyName': 'Freytag',
@@ -132,7 +133,7 @@ class SignupTest(IntegrationTest, StaticLiveServerTestCase):
         self.wait_for_element('.main-container')
 
         # check that we didn't get redirected
-        self.assertEqual(self.current_url, '/portal/register/',
+        self.assertEqual(self.current_url, reverse('register'),
                          'Check that the user stays on the first page')
         self.assertIn('uk-form-danger', self.selenium.find_element_by_id(
             'id_tos').get_attribute('class').split(' '), 'tos field marked up as incorrect')
@@ -140,7 +141,7 @@ class SignupTest(IntegrationTest, StaticLiveServerTestCase):
     def test_signup_alumniemail(self):
         """ Tests that we can not complete the first setup page with a jacobs alumni email """
 
-        self.submit_form('/portal/register/', 'input_id_submit', send_form_keys={
+        self.submit_form('register', 'input_id_submit', send_form_keys={
             'id_givenName': 'David',
             'id_middleName': 'L',
             'id_familyName': 'Hood',
@@ -158,7 +159,7 @@ class SignupTest(IntegrationTest, StaticLiveServerTestCase):
             'id_birthday': '1991-04-09',
         })
 
-        self.assertEqual(self.current_url, '/portal/register/',
+        self.assertEqual(self.current_url, reverse('register'),
                          'Check that the user stays on the first page')
         self.assertIn('uk-form-danger', self.selenium.find_element_by_id(
             'id_email').get_attribute('class').split(' '), 'email field marked up as incorrect')
@@ -166,7 +167,7 @@ class SignupTest(IntegrationTest, StaticLiveServerTestCase):
     def test_signup_jacobsemail(self):
         """ Tests that we can not complete the first setup page with a jacobs alumni email """
 
-        self.submit_form('/portal/register/', 'input_id_submit', send_form_keys={
+        self.submit_form(reverse('register'), 'input_id_submit', send_form_keys={
             'id_givenName': 'David',
             'id_middleName': 'L',
             'id_familyName': 'Hood',
@@ -184,7 +185,7 @@ class SignupTest(IntegrationTest, StaticLiveServerTestCase):
             'id_birthday': '1991-04-09',
         })
 
-        self.assertEqual(self.current_url, '/portal/register/',
+        self.assertEqual(self.current_url, reverse('register'),
                          'Check that the user stays on the first page')
         self.assertIn('uk-form-danger', self.selenium.find_element_by_id(
             'id_email').get_attribute('class').split(' '), 'email field marked up as incorrect')

--- a/registry/tests/test_signup_01_address.py
+++ b/registry/tests/test_signup_01_address.py
@@ -1,7 +1,8 @@
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
-from MemberManagement.tests.integration import IntegrationTest
+from django.urls import reverse
 
 from alumni.models import Alumni
+from MemberManagement.tests.integration import IntegrationTest
 
 
 class AddressTest(IntegrationTest, StaticLiveServerTestCase):
@@ -12,7 +13,7 @@ class AddressTest(IntegrationTest, StaticLiveServerTestCase):
         self.login('Mounfem')
 
     def test_signup_address_minimal(self):
-        self.submit_form('/portal/setup/address/', 'input_id_submit', send_form_keys={
+        self.submit_form('setup_address', 'input_id_submit', send_form_keys={
             'id_address_line_1': 'Alt-Moabit 72',
             'id_address_line_2': '',
             'id_city': 'Breunsdorf',
@@ -22,7 +23,7 @@ class AddressTest(IntegrationTest, StaticLiveServerTestCase):
             'id_country': ('DE',)
         })
 
-        self.assertEqual(self.current_url, '/portal/setup/social/',
+        self.assertEqual(self.current_url, reverse('setup_social'),
                          'Check that the user gets redirected to the social page')
 
         obj = Alumni.objects.first().address
@@ -34,7 +35,7 @@ class AddressTest(IntegrationTest, StaticLiveServerTestCase):
         self.assertEqual(obj.country.name, 'Germany')
 
     def test_signup_address_full(self):
-        self.submit_form('/portal/setup/address/', 'input_id_submit', send_form_keys={
+        self.submit_form('setup_address', 'input_id_submit', send_form_keys={
             'id_address_line_1': '2986 Heron Way',
             'id_address_line_2': 'Attn. Anna Freytag',
             'id_city': 'Portland',
@@ -44,7 +45,7 @@ class AddressTest(IntegrationTest, StaticLiveServerTestCase):
             'id_country': ('US',)
         })
 
-        self.assertEqual(self.current_url, '/portal/setup/social/',
+        self.assertEqual(self.current_url, reverse('setup_social'),
                          'Check that the user gets redirected to the social page')
 
         obj = Alumni.objects.first().address
@@ -57,7 +58,7 @@ class AddressTest(IntegrationTest, StaticLiveServerTestCase):
 
     def test_signup_address_fail(self):
         button = self.fill_out_form(
-            '/portal/setup/address/', 'input_id_submit')
+            'setup_address', 'input_id_submit')
 
         # remove all the 'required' elements
         self.disable_form_requirements()
@@ -67,7 +68,7 @@ class AddressTest(IntegrationTest, StaticLiveServerTestCase):
         self.wait_for_element('.main-container')
 
         # check that we didn't get redirected
-        self.assertEqual(self.current_url, '/portal/setup/address/',
+        self.assertEqual(self.current_url, reverse('setup_address'),
                          'Check that the user stays on the address page')
 
         for id_ in ['id_address_line_1', 'id_zip', 'id_city', 'id_country']:

--- a/registry/tests/test_signup_02_social.py
+++ b/registry/tests/test_signup_02_social.py
@@ -1,7 +1,9 @@
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
-from MemberManagement.tests.integration import IntegrationTest
+from django.urls import reverse
 
 from alumni.models import Alumni
+from MemberManagement.tests.integration import IntegrationTest
+
 
 class SocialTest(IntegrationTest, StaticLiveServerTestCase):
     fixtures = ['registry/tests/fixtures/signup_01_address.json']
@@ -11,7 +13,7 @@ class SocialTest(IntegrationTest, StaticLiveServerTestCase):
         self.login('Mounfem')
 
     def test_signup_social_complete(self):
-        self.submit_form('/portal/setup/social/', 'input_id_submit', send_form_keys={
+        self.submit_form('setup_social', 'input_id_submit', send_form_keys={
             'id_facebook': 'https://facebook.com/anna.freytag',
             'id_linkedin': 'https://www.linkedin.com/in/anna-freytag-1234578',
             'id_twitter': 'https://twitter.com/anna.freytag',
@@ -19,18 +21,19 @@ class SocialTest(IntegrationTest, StaticLiveServerTestCase):
             'id_homepage': 'https://anna-freytag.com'
         })
 
-        self.assertEqual(self.current_url, '/portal/setup/jacobs/',
+        self.assertEqual(self.current_url, reverse('setup_jacobs'),
                          'Check that the user gets redirected to the jacobs page')
 
         obj = Alumni.objects.first().social
         self.assertEqual(obj.facebook, 'https://facebook.com/anna.freytag')
-        self.assertEqual(obj.linkedin, 'https://www.linkedin.com/in/anna-freytag-1234578')
+        self.assertEqual(
+            obj.linkedin, 'https://www.linkedin.com/in/anna-freytag-1234578')
         self.assertEqual(obj.twitter, 'https://twitter.com/anna.freytag')
         self.assertEqual(obj.instagram, 'https://instagram.com/anna.freytag')
         self.assertEqual(obj.homepage, 'https://anna-freytag.com')
 
     def test_signup_social_empty(self):
-        self.submit_form('/portal/setup/social/', 'input_id_submit', send_form_keys={
+        self.submit_form('setup_social', 'input_id_submit', send_form_keys={
             'id_facebook': '',
             'id_linkedin': '',
             'id_twitter': '',
@@ -38,7 +41,7 @@ class SocialTest(IntegrationTest, StaticLiveServerTestCase):
             'id_homepage': ''
         })
 
-        self.assertEqual(self.current_url, '/portal/setup/jacobs/',
+        self.assertEqual(self.current_url, reverse('setup_jacobs'),
                          'Check that the user gets redirected to the jacobs page')
 
         obj = Alumni.objects.first().social

--- a/registry/tests/test_signup_03_jacobs.py
+++ b/registry/tests/test_signup_03_jacobs.py
@@ -1,11 +1,12 @@
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
-from MemberManagement.tests.integration import IntegrationTest
+from django.urls import reverse
 
-from alumni.models import Alumni
 from alumni.fields.college import CollegeField
 from alumni.fields.degree import DegreeField
 from alumni.fields.major import MajorField
 from alumni.fields.year import ClassField
+from alumni.models import Alumni
+from MemberManagement.tests.integration import IntegrationTest
 
 
 class JacobsTest(IntegrationTest, StaticLiveServerTestCase):
@@ -16,7 +17,7 @@ class JacobsTest(IntegrationTest, StaticLiveServerTestCase):
         self.login('Mounfem')
 
     def test_signup_jacobs_complete(self):
-        self.submit_form('/portal/setup/jacobs/', 'input_id_submit', send_form_keys={
+        self.submit_form('setup_jacobs', 'input_id_submit', send_form_keys={
             'id_comments': 'I am not real',
         }, select_dropdowns={
             'id_college': 'Nordmetall',
@@ -25,7 +26,7 @@ class JacobsTest(IntegrationTest, StaticLiveServerTestCase):
             'id_major': 'Physics',
         })
 
-        self.assertEqual(self.current_url, '/portal/setup/job/',
+        self.assertEqual(self.current_url, reverse('setup_job'),
                          'Check that the user gets redirected to the job page')
 
         obj = Alumni.objects.first().jacobs
@@ -36,7 +37,7 @@ class JacobsTest(IntegrationTest, StaticLiveServerTestCase):
         self.assertEqual(obj.comments, 'I am not real')
 
     def test_signup_jacobs_empty(self):
-        self.submit_form('/portal/setup/jacobs/', 'input_id_submit', send_form_keys={
+        self.submit_form('setup_jacobs', 'input_id_submit', send_form_keys={
             'id_comments': '',
         }, select_dropdowns={
             'id_college': None,
@@ -45,7 +46,7 @@ class JacobsTest(IntegrationTest, StaticLiveServerTestCase):
             'id_major': 'Other (Please specify in comments)',
         })
 
-        self.assertEqual(self.current_url, '/portal/setup/job/',
+        self.assertEqual(self.current_url, reverse('setup_job'),
                          'Check that the user gets redirected to the job page')
 
         obj = Alumni.objects.first().jacobs

--- a/registry/tests/test_signup_04_job.py
+++ b/registry/tests/test_signup_04_job.py
@@ -1,4 +1,5 @@
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
+from django.urls import reverse
 from MemberManagement.tests.integration import IntegrationTest
 
 from alumni.models import Alumni
@@ -14,7 +15,7 @@ class JobTest(IntegrationTest, StaticLiveServerTestCase):
         self.login('Mounfem')
 
     def test_signup_job_complete(self):
-        self.submit_form('/portal/setup/job/', 'input_id_submit', send_form_keys={
+        self.submit_form('setup_job', 'input_id_submit', send_form_keys={
             'id_employer': 'Solution Realty',
             'id_position': 'Junior Research Engineer',
         }, select_dropdowns={
@@ -22,7 +23,7 @@ class JobTest(IntegrationTest, StaticLiveServerTestCase):
             'id_job': 'Software Development / IT',
         })
 
-        self.assertEqual(self.current_url, '/portal/setup/skills/',
+        self.assertEqual(self.current_url, reverse('setup_skills'),
                          'Check that the user gets redirected to the skills page')
 
         obj = Alumni.objects.first().job
@@ -32,7 +33,7 @@ class JobTest(IntegrationTest, StaticLiveServerTestCase):
         self.assertEqual(obj.job, JobField.SOFTWARE_DEVELOPMENT_IT)
 
     def test_signup_job_empty(self):
-        self.submit_form('/portal/setup/job/', 'input_id_submit', send_form_keys={
+        self.submit_form('setup_job', 'input_id_submit', send_form_keys={
             'id_employer': '',
             'id_position': '',
         }, select_dropdowns={
@@ -40,7 +41,7 @@ class JobTest(IntegrationTest, StaticLiveServerTestCase):
             'id_job': 'Other',
         })
 
-        self.assertEqual(self.current_url, '/portal/setup/skills/',
+        self.assertEqual(self.current_url, reverse('setup_skills'),
                          'Check that the user gets redirected to the job page')
 
         obj = Alumni.objects.first().job

--- a/registry/tests/test_signup_05_skills.py
+++ b/registry/tests/test_signup_05_skills.py
@@ -1,4 +1,5 @@
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
+from django.urls import reverse
 from MemberManagement.tests.integration import IntegrationTest
 
 from alumni.models import Alumni
@@ -12,7 +13,7 @@ class SkillsTest(IntegrationTest, StaticLiveServerTestCase):
         self.login('Mounfem')
 
     def test_signup_skills_complete(self):
-        self.submit_form('/portal/setup/skills/', 'input_id_submit', send_form_keys={
+        self.submit_form('setup_skills', 'input_id_submit', send_form_keys={
             'id_otherDegrees': 'Bachelor of Computer Science from IUB',
             'id_spokenLanguages': 'German, English, Spanish',
             'id_programmingLanguages': 'HTML, CSS, JavaScript, Python',
@@ -21,7 +22,7 @@ class SkillsTest(IntegrationTest, StaticLiveServerTestCase):
             'id_alumniMentor': True,
         })
 
-        self.assertEqual(self.current_url, '/portal/setup/atlas/',
+        self.assertEqual(self.current_url, reverse('setup_atlas'),
                          'Check that the user gets redirected to the atlas page')
 
         obj = Alumni.objects.first().skills
@@ -32,7 +33,7 @@ class SkillsTest(IntegrationTest, StaticLiveServerTestCase):
         self.assertEqual(obj.alumniMentor, True)
 
     def test_signup_job_empty(self):
-        self.submit_form('/portal/setup/skills/', 'input_id_submit', send_form_keys={
+        self.submit_form('setup_skills', 'input_id_submit', send_form_keys={
             'id_otherDegrees': '',
             'id_spokenLanguages': '',
             'id_programmingLanguages': '',
@@ -41,7 +42,7 @@ class SkillsTest(IntegrationTest, StaticLiveServerTestCase):
             'id_alumniMentor': False,
         })
 
-        self.assertEqual(self.current_url, '/portal/setup/atlas/',
+        self.assertEqual(self.current_url, reverse('setup_atlas'),
                          'Check that the user gets redirected to the atlas page')
 
         obj = Alumni.objects.first().skills

--- a/registry/tests/test_signup_06_atlas.py
+++ b/registry/tests/test_signup_06_atlas.py
@@ -1,7 +1,8 @@
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
-from MemberManagement.tests.integration import IntegrationTest
+from django.urls import reverse
 
 from alumni.models import Alumni
+from MemberManagement.tests.integration import IntegrationTest
 
 
 class AtlasTest(IntegrationTest, StaticLiveServerTestCase):
@@ -12,13 +13,13 @@ class AtlasTest(IntegrationTest, StaticLiveServerTestCase):
         self.login('Mounfem')
 
     def test_signup_atlas_all(self):
-        self.submit_form('/portal/setup/atlas/', 'input_id_submit', select_checkboxes={
+        self.submit_form('setup_atlas', 'input_id_submit', select_checkboxes={
             'id_included': True,
             'id_birthdayVisible': True,
             'id_contactInfoVisible': True,
         })
 
-        self.assertEqual(self.current_url, '/payments/membership/',
+        self.assertEqual(self.current_url, reverse('setup_membership'),
                          'Check that the user gets redirected to the membership page')
 
         obj = Alumni.objects.first().atlas
@@ -27,13 +28,13 @@ class AtlasTest(IntegrationTest, StaticLiveServerTestCase):
         self.assertEqual(obj.contactInfoVisible, True)
 
     def test_signup_atlas_birthday(self):
-        self.submit_form('/portal/setup/atlas/', 'input_id_submit', select_checkboxes={
+        self.submit_form('setup_atlas', 'input_id_submit', select_checkboxes={
             'id_included': True,
             'id_birthdayVisible': True,
             'id_contactInfoVisible': False,
         })
 
-        self.assertEqual(self.current_url, '/payments/membership/',
+        self.assertEqual(self.current_url, reverse('setup_membership'),
                          'Check that the user gets redirected to the membership page')
 
         obj = Alumni.objects.first().atlas
@@ -42,13 +43,13 @@ class AtlasTest(IntegrationTest, StaticLiveServerTestCase):
         self.assertEqual(obj.contactInfoVisible, False)
 
     def test_signup_atlas_contact(self):
-        self.submit_form('/portal/setup/atlas/', 'input_id_submit', select_checkboxes={
+        self.submit_form('setup_atlas', 'input_id_submit', select_checkboxes={
             'id_included': True,
             'id_birthdayVisible': False,
             'id_contactInfoVisible': True,
         })
 
-        self.assertEqual(self.current_url, '/payments/membership/',
+        self.assertEqual(self.current_url, reverse('setup_membership'),
                          'Check that the user gets redirected to the membership page')
 
         obj = Alumni.objects.first().atlas
@@ -57,13 +58,13 @@ class AtlasTest(IntegrationTest, StaticLiveServerTestCase):
         self.assertEqual(obj.contactInfoVisible, True)
 
     def test_signup_atlas_minimal(self):
-        self.submit_form('/portal/setup/atlas/', 'input_id_submit', select_checkboxes={
+        self.submit_form('setup_atlas', 'input_id_submit', select_checkboxes={
             'id_included': True,
             'id_birthdayVisible': False,
             'id_contactInfoVisible': False,
         })
 
-        self.assertEqual(self.current_url, '/payments/membership/',
+        self.assertEqual(self.current_url, reverse('setup_membership'),
                          'Check that the user gets redirected to the membership page')
 
         obj = Alumni.objects.first().atlas
@@ -72,13 +73,13 @@ class AtlasTest(IntegrationTest, StaticLiveServerTestCase):
         self.assertEqual(obj.contactInfoVisible, False)
 
     def test_signup_atlas_empty(self):
-        self.submit_form('/portal/setup/atlas/', 'input_id_submit', select_checkboxes={
+        self.submit_form('setup_atlas', 'input_id_submit', select_checkboxes={
             'id_included': False,
             'id_birthdayVisible': False,
             'id_contactInfoVisible': False,
         })
 
-        self.assertEqual(self.current_url, '/payments/membership/',
+        self.assertEqual(self.current_url, reverse('setup_membership'),
                          'Check that the user gets redirected to the membership page')
 
         obj = Alumni.objects.first().atlas

--- a/registry/tests/test_signup_07a_starter.py
+++ b/registry/tests/test_signup_07a_starter.py
@@ -1,15 +1,14 @@
-from django.contrib.staticfiles.testing import StaticLiveServerTestCase
-from MemberManagement.tests.integration import IntegrationTest
-
-from django.utils import timezone
 from datetime import timedelta
-
 from unittest import mock
 
-from alumni.models import Alumni
-from alumni.fields.tier import TierField
+from django.contrib.staticfiles.testing import StaticLiveServerTestCase
+from django.urls import reverse
+from django.utils import timezone
 
-from payments.models import SubscriptionInformation, MembershipInformation
+from alumni.fields.tier import TierField
+from alumni.models import Alumni
+from MemberManagement.tests.integration import IntegrationTest
+from payments.models import MembershipInformation, SubscriptionInformation
 
 MOCKED_TIME = timezone.datetime(
     2019, 9, 19, 16, 41, 17, 40, tzinfo=timezone.utc)
@@ -25,7 +24,7 @@ class StarterTest(IntegrationTest, StaticLiveServerTestCase):
 
     def test_setup_starter_elements(self):
         # fill out the form and select the starter tier
-        self.fill_out_form('/payments/membership/', 'input_id_submit', select_dropdowns={
+        self.fill_out_form('setup_membership', 'input_id_submit', select_dropdowns={
             "id_tier": 'Starter – Free Membership for 0€ p.a.'
         })
 
@@ -39,11 +38,11 @@ class StarterTest(IntegrationTest, StaticLiveServerTestCase):
     @mock.patch('django.utils.timezone.now', mock.Mock(return_value=MOCKED_TIME))
     def test_setup_starter(self):
         with mock.patch('payments.stripewrapper.create_customer', return_value=(MOCKED_CUSTOMER, None)) as mocked:
-            self.submit_form('/payments/membership/', 'input_id_submit', select_dropdowns={
+            self.submit_form('setup_membership', 'input_id_submit', select_dropdowns={
                 "id_tier": 'Starter – Free Membership for 0€ p.a.'
             })
 
-            self.assertEqual(self.current_url, '/portal/setup/completed/',
+            self.assertEqual(self.current_url, reverse('setup_setup'),
                              'Check that the user gets redirected to the final page')
 
             # check that the stripe api was called with the object as a parameter
@@ -67,7 +66,7 @@ class StarterTest(IntegrationTest, StaticLiveServerTestCase):
     def test_setup_starter_fail(self):
         with mock.patch('payments.stripewrapper.create_customer', return_value=(None, "debug")) as mocked:
             # fill out the form an select the starter tier
-            btn = self.fill_out_form('/payments/membership/', 'input_id_submit', select_dropdowns={
+            btn = self.fill_out_form('setup_membership', 'input_id_submit', select_dropdowns={
                 "id_tier": 'Starter – Free Membership for 0€ p.a.'
             })
 
@@ -76,7 +75,7 @@ class StarterTest(IntegrationTest, StaticLiveServerTestCase):
             self.wait_for_element(None)
 
             # we stay on the same page
-            self.assertEqual(self.current_url, '/payments/membership/',
+            self.assertEqual(self.current_url, reverse('setup_membership'),
                              'Check that the user does not get redirected to the final page')
 
             # check that the stripe api was called with the object as a parameter

--- a/registry/tests/test_signup_07b_contributor.py
+++ b/registry/tests/test_signup_07b_contributor.py
@@ -1,4 +1,5 @@
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
+from django.urls import reverse
 from MemberManagement.tests.integration import IntegrationTest
 
 from unittest import mock
@@ -20,7 +21,7 @@ class ContributorTest(IntegrationTest, StaticLiveServerTestCase):
 
     def test_setup_contributor_elements(self):
         # fill out the form and select the contributor tier
-        self.fill_out_form('/payments/membership/', 'input_id_submit', select_dropdowns={
+        self.fill_out_form('setup_membership', 'input_id_submit', select_dropdowns={
             "id_tier": 'Contributor – Standard membership for 39€ p.a.'
         })
 
@@ -34,11 +35,11 @@ class ContributorTest(IntegrationTest, StaticLiveServerTestCase):
     def test_setup_contributor(self):
         with mock.patch('payments.stripewrapper.create_customer', return_value=(MOCKED_CUSTOMER, None)) as mocked:
             # fill out the form an select the contributor tier
-            self.submit_form('/payments/membership/', 'input_id_submit', select_dropdowns={
+            self.submit_form('setup_membership', 'input_id_submit', select_dropdowns={
                 "id_tier": 'Contributor – Standard membership for 39€ p.a.'
             })
 
-            self.assertEqual(self.current_url, '/payments/subscribe/',
+            self.assertEqual(self.current_url, reverse('setup_subscription'),
                              'Check that the user gets redirected to the subscription page')
 
             # check that the stripe api was called with the object as a parameter
@@ -58,12 +59,12 @@ class ContributorTest(IntegrationTest, StaticLiveServerTestCase):
     def test_setup_contributor_fail(self):
         with mock.patch('payments.stripewrapper.create_customer', return_value=(None, "debug")) as mocked:
             # fill out the form an select the payments tier
-            self.submit_form('/payments/membership/', 'input_id_submit', select_dropdowns={
+            self.submit_form('setup_membership', 'input_id_submit', select_dropdowns={
                 "id_tier": 'Contributor – Standard membership for 39€ p.a.'
             })
 
             # we stay on the same page
-            self.assertEqual(self.current_url, '/payments/membership/',
+            self.assertEqual(self.current_url, reverse('setup_membership'),
                              'Check that the user does not get redirected to the final page')
 
             # check that the stripe api was called with the object as a parameter

--- a/registry/tests/test_signup_07c_patron.py
+++ b/registry/tests/test_signup_07c_patron.py
@@ -1,4 +1,5 @@
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
+from django.urls import reverse
 from MemberManagement.tests.integration import IntegrationTest
 
 from unittest import mock
@@ -20,7 +21,7 @@ class PatronTest(IntegrationTest, StaticLiveServerTestCase):
 
     def test_setup_patron_elements(self):
         # fill out the form and select the patron tier
-        self.fill_out_form('/payments/membership/', 'input_id_submit', select_dropdowns={
+        self.fill_out_form('setup_membership', 'input_id_submit', select_dropdowns={
             "id_tier": 'Patron – Premium membership for 249€ p.a.'
         })
 
@@ -34,11 +35,11 @@ class PatronTest(IntegrationTest, StaticLiveServerTestCase):
     def test_setup_patron(self):
         with mock.patch('payments.stripewrapper.create_customer', return_value=(MOCKED_CUSTOMER, None)) as mocked:
             # fill out the form an select the patron tier
-            self.submit_form('/payments/membership/', 'input_id_submit', select_dropdowns={
+            self.submit_form('setup_membership', 'input_id_submit', select_dropdowns={
                 "id_tier": 'Patron – Premium membership for 249€ p.a.'
             })
 
-            self.assertEqual(self.current_url, '/payments/subscribe/',
+            self.assertEqual(self.current_url, reverse('setup_subscription'),
                              'Check that the user gets redirected to the subscription page')
 
             # check that the stripe api was called with the object as a parameter
@@ -58,12 +59,12 @@ class PatronTest(IntegrationTest, StaticLiveServerTestCase):
     def test_setup_patron_fail(self):
         with mock.patch('payments.stripewrapper.create_customer', return_value=(None, "debug")) as mocked:
             # fill out the form an select the payments tier
-            self.submit_form('/payments/membership/', 'input_id_submit', select_dropdowns={
+            self.submit_form('setup_membership', 'input_id_submit', select_dropdowns={
                 "id_tier": 'Patron – Premium membership for 249€ p.a.'
             })
 
             # we stay on the same page
-            self.assertEqual(self.current_url, '/payments/membership/',
+            self.assertEqual(self.current_url, reverse('setup_membership'),
                              'Check that the user does not get redirected to the final page')
 
             # check that the stripe api was called with the object as a parameter

--- a/registry/tests/test_signup_08_common.py
+++ b/registry/tests/test_signup_08_common.py
@@ -2,7 +2,7 @@ from selenium.webdriver.support.ui import Select
 
 class CommonSignupTest:
     def test_select_card(self):
-        element = self.sget('/payments/subscribe/', '#id_payment_type')
+        element = self.sget('setup_subscription', '#id_payment_type')
         submit = self.wait_for_element('#button_id_presubmit', clickable=True)
 
         # select debit card payment method
@@ -14,7 +14,7 @@ class CommonSignupTest:
             'stripe-iban-elements').is_displayed())
 
     def test_select_iban(self):
-        element = self.sget('/payments/subscribe/', '#id_payment_type')
+        element = self.sget('setup_subscription', '#id_payment_type')
         submit = self.wait_for_element('#button_id_presubmit', clickable=True)
 
         # select debit card payment method
@@ -29,7 +29,7 @@ class CommonSignupTest:
         """ Fills out and submits testing card details """
 
         # load the subscribe page and wait for the submit button to be clickable
-        element = self.sget('/payments/subscribe/', '#id_payment_type')
+        element = self.sget('setup_subscription', '#id_payment_type')
         submit = self.wait_for_element('#button_id_presubmit', clickable=True)
 
         # select debit card payment method
@@ -52,7 +52,7 @@ class CommonSignupTest:
         """ Fills out and submits testing SEPA details """
 
         # load the subscribe page and wait for the submit button to be clickable
-        element = self.sget('/payments/subscribe/', '#id_payment_type')
+        element = self.sget('setup_subscription', '#id_payment_type')
         submit = self.wait_for_element('#button_id_presubmit', clickable=True)
 
         # select sepa payment method

--- a/registry/tests/test_signup_08b_contributor.py
+++ b/registry/tests/test_signup_08b_contributor.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
+from django.urls import reverse
 from django.utils import timezone
 
 from alumni.fields.tier import TierField
@@ -30,7 +31,7 @@ class ContributorSubscribeTest(CommonSignupTest, IntegrationTest, StaticLiveServ
                 self.submit_card_details()
 
                 # check that things are as expected
-                self.assertEqual(self.current_url, '/portal/setup/completed/',
+                self.assertEqual(self.current_url, reverse('setup_setup'),
                                  'Check that the user gets redirected to the completed page')
 
                 # check that the mocks were called
@@ -56,7 +57,7 @@ class ContributorSubscribeTest(CommonSignupTest, IntegrationTest, StaticLiveServ
                 self.submit_card_details()
 
                 # check that things are as expected
-                self.assertEqual(self.current_url, '/payments/subscribe/',
+                self.assertEqual(self.current_url, reverse('setup_subscription'),
                                  'Check that the user stays on the first page')
 
                 # check that only the first mock was called
@@ -77,7 +78,7 @@ class ContributorSubscribeTest(CommonSignupTest, IntegrationTest, StaticLiveServ
                 self.submit_card_details()
 
                 # check that things are as expected
-                self.assertEqual(self.current_url, '/payments/subscribe/',
+                self.assertEqual(self.current_url, reverse('setup_subscription'),
                                  'Check that the user stays on the subscribe page')
 
                 # check that only the first mock was called
@@ -98,7 +99,7 @@ class ContributorSubscribeTest(CommonSignupTest, IntegrationTest, StaticLiveServ
                 self.submit_sepa_details()
 
                 # check that things are as expected
-                self.assertEqual(self.current_url, '/portal/setup/completed/',
+                self.assertEqual(self.current_url, reverse('setup_setup'),
                                  'Check that the user gets redirected to the completed page')
 
                 # check that the mocks were called
@@ -126,7 +127,7 @@ class ContributorSubscribeTest(CommonSignupTest, IntegrationTest, StaticLiveServ
                 self.submit_sepa_details()
 
                 # check that things are as expected
-                self.assertEqual(self.current_url, '/payments/subscribe/',
+                self.assertEqual(self.current_url, reverse('setup_subscription'),
                                  'Check that the user stays on the first page')
 
                 # check that only the first mock was called
@@ -147,7 +148,7 @@ class ContributorSubscribeTest(CommonSignupTest, IntegrationTest, StaticLiveServ
                 self.submit_sepa_details()
 
                 # check that things are as expected
-                self.assertEqual(self.current_url, '/payments/subscribe/',
+                self.assertEqual(self.current_url, reverse('setup_subscription'),
                                  'Check that the user stays on the subscribe page')
 
                 # check that only the first mock was called

--- a/registry/tests/test_signup_08c_patron.py
+++ b/registry/tests/test_signup_08c_patron.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
+from django.urls import reverse
 from django.utils import timezone
 
 from alumni.fields.tier import TierField
@@ -30,7 +31,7 @@ class PatronSubscribeTest(CommonSignupTest, IntegrationTest, StaticLiveServerTes
                 self.submit_card_details()
 
                 # check that things are as expected
-                self.assertEqual(self.current_url, '/portal/setup/completed/',
+                self.assertEqual(self.current_url, reverse('setup_setup'),
                                  'Check that the user gets redirected to the completed page')
 
                 # check that the mocks were called
@@ -56,7 +57,7 @@ class PatronSubscribeTest(CommonSignupTest, IntegrationTest, StaticLiveServerTes
                 self.submit_card_details()
 
                 # check that things are as expected
-                self.assertEqual(self.current_url, '/payments/subscribe/',
+                self.assertEqual(self.current_url, reverse('setup_subscription'),
                                  'Check that the user stays on the first page')
 
                 # check that only the first mock was called
@@ -77,7 +78,7 @@ class PatronSubscribeTest(CommonSignupTest, IntegrationTest, StaticLiveServerTes
                 self.submit_card_details()
 
                 # check that things are as expected
-                self.assertEqual(self.current_url, '/payments/subscribe/',
+                self.assertEqual(self.current_url, reverse('setup_subscription'),
                                  'Check that the user stays on the subscribe page')
 
                 # check that only the first mock was called
@@ -98,7 +99,7 @@ class PatronSubscribeTest(CommonSignupTest, IntegrationTest, StaticLiveServerTes
                 self.submit_sepa_details()
 
                 # check that things are as expected
-                self.assertEqual(self.current_url, '/portal/setup/completed/',
+                self.assertEqual(self.current_url, reverse('setup_setup'),
                                  'Check that the user gets redirected to the completed page')
 
                 # check that the mocks were called
@@ -126,7 +127,7 @@ class PatronSubscribeTest(CommonSignupTest, IntegrationTest, StaticLiveServerTes
                 self.submit_sepa_details()
 
                 # check that things are as expected
-                self.assertEqual(self.current_url, '/payments/subscribe/',
+                self.assertEqual(self.current_url, reverse('setup_subscription'),
                                  'Check that the user stays on the first page')
 
                 # check that only the first mock was called
@@ -147,7 +148,7 @@ class PatronSubscribeTest(CommonSignupTest, IntegrationTest, StaticLiveServerTes
                 self.submit_sepa_details()
 
                 # check that things are as expected
-                self.assertEqual(self.current_url, '/payments/subscribe/',
+                self.assertEqual(self.current_url, reverse('setup_subscription'),
                                  'Check that the user stays on the subscribe page')
 
                 # check that only the first mock was called

--- a/registry/tests/test_signup_09_finalize.py
+++ b/registry/tests/test_signup_09_finalize.py
@@ -1,13 +1,14 @@
-from django.contrib.staticfiles.testing import StaticLiveServerTestCase
-from MemberManagement.tests.integration import IntegrationTest
-
-from django.utils import timezone
-
 from unittest import mock
 
-from alumni.models import Alumni
+from django.contrib.staticfiles.testing import StaticLiveServerTestCase
+from django.urls import reverse
+from django.utils import timezone
 
-MOCKED_TIME = timezone.datetime(2019, 9, 19, 16, 42, 5, 269, tzinfo=timezone.utc)
+from alumni.models import Alumni
+from MemberManagement.tests.integration import IntegrationTest
+
+MOCKED_TIME = timezone.datetime(
+    2019, 9, 19, 16, 42, 5, 269, tzinfo=timezone.utc)
 
 
 class FinalizeTest(IntegrationTest, StaticLiveServerTestCase):
@@ -19,9 +20,9 @@ class FinalizeTest(IntegrationTest, StaticLiveServerTestCase):
 
     @mock.patch('django.utils.timezone.now', mock.Mock(return_value=MOCKED_TIME))
     def test_setup_finalize(self):
-        self.submit_form('/portal/setup/completed/', 'input_id_submit')
+        self.submit_form('setup_setup', 'input_id_submit')
 
-        self.assertEqual(self.current_url, '/portal/',
+        self.assertEqual(self.current_url, reverse('portal'),
                          'Check that the user gets redirected to the portal page')
 
         obj = Alumni.objects.first().setup

--- a/registry/views/setup.py
+++ b/registry/views/setup.py
@@ -1,17 +1,16 @@
-from django.views.generic.base import View, TemplateResponseMixin
-
-from django.utils.decorators import method_decorator
-
 from django.contrib.auth import login
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User
+from django.utils.decorators import method_decorator
+from django.views.generic.base import TemplateResponseMixin, View
 
 from alumni.models import Approval
-from registry.decorators import require_alumni
-from ..forms import RegistrationForm, AddressForm, JacobsForm, SocialMediaForm, \
-    JobInformationForm, SkillsForm, AtlasSettingsForm, SetupCompletedForm
-
 from MemberManagement.mixins import RedirectResponseMixin
+from registry.decorators import require_alumni
+
+from ..forms import (AddressForm, AtlasSettingsForm, JacobsForm,
+                     JobInformationForm, RegistrationForm, SetupCompletedForm,
+                     SkillsForm, SocialMediaForm)
 
 
 @method_decorator(login_required, name='dispatch')
@@ -47,7 +46,6 @@ class SetupViewBase(RedirectResponseMixin, TemplateResponseMixin, View):
         """ returns True iff this setup component is the next valid setup component """
 
         raise NotImplementedError
-
 
     def dispatch_already_set(self):
         """ called when setup component already exists """
@@ -120,7 +118,7 @@ class RegisterView(SetupViewBase):
         return True
 
     def dispatch_already_set(self):
-        return self.redirect_response('/')
+        return self.redirect_response('root', reverse=True)
 
     def form_valid(self, form):
         """ Called when the form is valid and an instance is to be created """


### PR DESCRIPTION
This commit updates all files to use reverse() instead of hard-coded
urls. This in particular includes the URLS.