### PR TITLE
Bugfix tier change flow

### DIFF
--- a/payments/models.py
+++ b/payments/models.py
@@ -66,8 +66,11 @@ class MembershipInformation(AlumniComponentMixin, models.Model):
             instance.created_from_update = True
         return instance
 
-    def change_tier(self, desired_tier):
+    def change_tier(self):
         """ Designates this user as changing tier """
+
+        # the tier we want to switch to
+        desired_tier = self.desired_tier
 
         # if the desired tier is none, we are already done
         if desired_tier is None:
@@ -150,6 +153,7 @@ class MembershipInformation(AlumniComponentMixin, models.Model):
         # end the current subscription, set the new tier
         sub.set_end()
         self.tier = desired_tier
+        self.desired_tier = None
         self.save()
 
         # Create the new subscription

--- a/registry/views/setup.py
+++ b/registry/views/setup.py
@@ -76,6 +76,11 @@ class SetupViewBase(RedirectResponseMixin, TemplateResponseMixin, View):
             'next_text': self.__class__.setup_next_text,
         }
 
+    def dispatch_form(self, form):
+        """ Called to dispatch the form to be filled out """
+
+        return self.render_to_response(self.get_context(form))
+
     def dispatch(self, *args, **kwargs):
         """ Dispatches this form """
 
@@ -103,7 +108,7 @@ class SetupViewBase(RedirectResponseMixin, TemplateResponseMixin, View):
                 return self.dispatch_success(success)
 
         # else render the form
-        return self.render_to_response(self.get_context(form))
+        return self.dispatch_form(form)
 
 
 class RegisterView(SetupViewBase):


### PR DESCRIPTION
The newly implemented tier change flow contained several regressions. In particular, messages were displayed more than once, and too many redirects were involed. This PR fixes the issue.