### PR TITLE
Fix incorrect link in atlas search page

### DIFF
--- a/atlas/templates/atlas/search.html
+++ b/atlas/templates/atlas/search.html
@@ -26,11 +26,11 @@ Jacobs Alumni Search - {{query}}
                     <th>Degree</th>
                     <th>City</th>
                 </tr>
-            </thead>
+        </thead>
             <tbody>
             {% for alumni in page %}
                 <tr>
-                    <td><a href="{% url 'atlas_profile' id=alumni.profile.id %}" class='search_result_link'>{{ alumni.givenName }} {{ alumni.familyName }}</a></td>
+                    <td><a href="{% url 'atlas_profile' id=alumni.id %}" class='search_result_link'>{{ alumni.givenName }} {{ alumni.familyName }}</a></td>
                     <td>
                         {% if alumni.jacobs.degree %}
                             {{ alumni.jacobs|get_choice_field:"degree" }}, 


### PR DESCRIPTION
Previously, when listing results on the atlas search page the IDs for
Alumni Profiles were used to generate links to individual results.
However, when generating the individual result page, the Alumni Object
ID was used to show the result page.

In most cases these IDs were identical and did not cause a problem.
However in certain cases, they were different and lead to unexpected
results. This PR fixes the issue by using Alumni IDs in both cases.